### PR TITLE
fix(guide): asciidoctor compatible with Gradle 9.5

### DIFF
--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2018-2025 Agorapulse.
+ * Copyright 2018-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,9 @@
  */
 plugins {
     id 'com.agorapulse.gradle.guide'
-    id 'org.ajoberstar.git-publish'
-}
-
-configurations {
-    asciidoctorExtensions
-}
-
-dependencies {
-    asciidoctorExtensions 'com.bmuschko:asciidoctorj-tabbed-code-extension:0.3'
 }
 
 asciidoctor {
-    configurations 'asciidoctorExtensions'
-
     baseDirFollowsSourceDir()
 
     attributes = [


### PR DESCRIPTION
## Summary

The `1.0.0.RC1` release workflow failed on `:guide:asciidoctor` with `UnionFileCollection cannot be cast to Configuration`. The asciidoctor jvm plugin's `configurations 'name'` resolution doesn't survive Gradle 9.5, so the guide build crashes before any publication step.

This PR aligns `docs/guide/guide.gradle` with the [micronaut-rethrow guide](https://github.com/agorapulse/micronaut-rethrow/blob/master/docs/guide/guide.gradle) exemplar:

- Drops the locally-declared `asciidoctorExtensions` configuration plus its `com.bmuschko:asciidoctorj-tabbed-code-extension` dependency. The guide contains no `[tabs]` blocks, so the extension was dead weight.
- Drops the explicit `id 'org.ajoberstar.git-publish'` application — `com.agorapulse.gradle.guide` wires git-publish internally with Gradle-9-compatible settings.

`:guide:asciidoctor` succeeds locally on Gradle 9.5 / Java 25 after the change.

## Test plan

- [x] `./gradlew :guide:asciidoctor` succeeds locally
- [ ] Once merged, re-cut `1.0.0.RC1` (delete and recreate the GitHub Release, or tag a new `1.0.0.RC2`) so the publishing workflow can run

🤖 Generated with [Claude Code](https://claude.com/claude-code)