### PR TITLE
fix(release): set git identity before gitPublishCommit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
       - uses: gradle/actions/setup-gradle@v4
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}


### PR DESCRIPTION
## Summary

After PR #23 cleared the asciidoctor failure, the next 1.0.0.RC1 / 1.0.0.RC2 release attempt fails on `:guide:gitPublishCommit` because the runner has no git user identity set:

```
git config --global user.email "you@example.com"
git config --global user.name "Your Name"
```

This PR adds a `Configure git identity for gitPublishCommit` step that pins the identity to `Agorapulse Bot` / `oss@agorapulse.com` just before the `./gradlew gitPublishPush ...` invocation. Matches the pattern that was landed on micronaut-rethrow when the same workflow change hit Gradle 9.

## Test plan

- [ ] Once merged, re-cut the release (recreate the GitHub Release for the existing `1.0.0.RC2` tag, or tag `1.0.0.RC3`) so the publishing workflow can run end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)