### PR TITLE
fix(release): set gitPublish.username / password from env (real bot user)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
-        run: ./gradlew gitPublishPush publishAndReleaseToMavenCentral "-Pversion=${{ github.ref_name }}" -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} -Prelease=true "-Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}" --stacktrace
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral "-Pversion=${{ github.ref_name }}" -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} -Prelease=true --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -19,6 +19,14 @@ plugins {
     id 'com.agorapulse.gradle.guide'
 }
 
+// gradle-git-publish 5.x no longer reads GRGIT_USER / GRGIT_PASS env vars
+// (or the org.ajoberstar.grgit.auth.* system properties). HTTPS push
+// credentials must be set on the gitPublish extension directly.
+gitPublish {
+    username = providers.environmentVariable('GIT_PUBLISH_USERNAME').orElse('')
+    password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
+}
+
 asciidoctor {
     baseDirFollowsSourceDir()
 


### PR DESCRIPTION
## Summary

The 1.0.0.RC2 / RC3 retries reached `:guide:gitPublishPush` (so PR #23 + PR #24 did clear the previous blockers) but then crashed with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

`gradle-git-publish:5.1.2` — pulled in by `com.agorapulse.gradle.guide` — dropped the legacy `GRGIT_USER` / `GRGIT_PASS` env vars and the `-Dorg.ajoberstar.grgit.auth.username=...` system property the old Kordamp-era workflow relied on. The v5 README is explicit:

> If you relied on Grgit's authentication, such as GRGIT_USER, use the new username and password properties on the GitPublication.

This PR applies exactly the fix that landed on micronaut-rethrow at the 3.0.0.RC3 tag (commit [3ee67e9](https://github.com/agorapulse/micronaut-rethrow/commit/3ee67e9a817b61d0f1e64846be888d11f91be7c4)) — that's the rethrow tag that *actually* released end-to-end:

- **`docs/guide/guide.gradle`** — set credentials on the `gitPublish` extension directly, reading from `GIT_PUBLISH_USERNAME` / `GIT_PUBLISH_PASSWORD` env vars:

  ```groovy
  gitPublish {
      username = providers.environmentVariable('GIT_PUBLISH_USERNAME').orElse('')
      password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
  }
  ```

- **`.github/workflows/release.yml`** — pass `agorapulse-bot` as username and the existing `AGORAPULSE_BOT_PERSONAL_TOKEN` as password (standard GitHub HTTPS basic-auth). Drop the now-useless `-Dorg.ajoberstar.grgit.auth.username=…` flag. Qualify the task path to `:guide:gitPublishPush` so the gradle command matches the rethrow exemplar 1:1.

## Test plan

- [ ] After merge, recreate the GitHub Release on the existing `1.0.0.RC3` tag (or cut `1.0.0.RC4`) so the publishing workflow runs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)