### PR TITLE
fix(fixt): system properties override env vars for TEST_RESOURCES_FOLDER

### DIFF
--- a/libs/fixt/src/main/groovy/com/agorapulse/testing/fixt/Fixt.java
+++ b/libs/fixt/src/main/groovy/com/agorapulse/testing/fixt/Fixt.java
@@ -75,16 +75,21 @@ public class Fixt {
      */
     public static String getTestResourcesLocation() {
         String testResourcesFolder = FileSystems.getDefault().getPath("src", "test", "resources").toString();
-        for (Map.Entry<Object, Object> property : System.getProperties().entrySet()) {
-            String canonicalKey = property.getKey().toString().replaceAll(IGNORED_CHARACTERS, "");
-            if (canonicalKey.equalsIgnoreCase(TEST_RESOURCES_FOLDER_PROPERTY_NAME) && property.getValue() != null) {
-                testResourcesFolder = property.getValue().toString();
-            }
-        }
+        // Environment variables are read first so that a System.setProperty call from inside
+        // a test (e.g. to redirect writes to a JUnit/Spock @TempDir) takes precedence over
+        // any default TEST_RESOURCES_FOLDER baked into the build (Gradle's
+        // `test.environment(...)`). System properties are the canonical JVM-level override
+        // and need to win.
         for (Map.Entry<String, String> property : System.getenv().entrySet()) {
             String canonicalKey = property.getKey().replaceAll(IGNORED_CHARACTERS, "");
             if (canonicalKey.equalsIgnoreCase(TEST_RESOURCES_FOLDER_PROPERTY_NAME) && property.getValue() != null) {
                 testResourcesFolder = property.getValue();
+            }
+        }
+        for (Map.Entry<Object, Object> property : System.getProperties().entrySet()) {
+            String canonicalKey = property.getKey().toString().replaceAll(IGNORED_CHARACTERS, "");
+            if (canonicalKey.equalsIgnoreCase(TEST_RESOURCES_FOLDER_PROPERTY_NAME) && property.getValue() != null) {
+                testResourcesFolder = property.getValue().toString();
             }
         }
         return testResourcesFolder;


### PR DESCRIPTION
## Summary

`Fixt.getTestResourcesLocation()` iterated `System.getProperties()` first, then `System.getenv()`, with every match overwriting the previous result. That made env vars win — which is the wrong precedence.

When a Gradle build sets `test.environment('TEST_RESOURCES_FOLDER', '<projectDir>/src/test/resources')` (which the agorapulse `java-common-configuration` plugin does on every test task), an in-test `System.setProperty('TEST_RESOURCES_FOLDER', tmp.path)` — the standard way to redirect fixt writes to a JUnit/Spock `@TempDir` — gets silently ignored.

Swap the iteration order so env runs first and system properties run second. Now `System.setProperty` (the canonical JVM-level override) takes precedence, while the build-time env var remains the baseline tests inherit by default.

This unblocks gru's `TextMinionSpec` / `JsonMinionSpec` "fixture file is created" tests, which redirect writes via `System.setProperty`.

## Test plan

- [x] `./gradlew :fixt:test` passes locally on Gradle 9.5 / Java 25 / Groovy 5 / Spock 2.4-groovy-5.0
- [ ] After merge, cut `1.0.0.RC5` (or whatever version comes next) so downstream consumers can bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)